### PR TITLE
Add explicitly the locale to UTF-8

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,15 @@
 FROM ubuntu:focal
 
 # hadolint ignore=DL3008
-RUN apt-get update && apt-get install --no-install-recommends -y curl xz-utils vim  ca-certificates && apt-get clean && rm -rf /var/lib/apt/lists/* \
+RUN apt-get update && apt-get install --no-install-recommends -y  locales curl xz-utils vim  ca-certificates && apt-get clean && rm -rf /var/lib/apt/lists/* \
       && mkdir -m 0755 /nix && groupadd -r nixbld && chown root /nix \
       && for n in $(seq 1 10); do useradd -c "Nix build user $n" -d /var/empty -g nixbld -G nixbld -M -N -r -s "$(command -v nologin)" "nixbld$n"; done
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -o pipefail && curl -L https://nixos.org/nix/install | bash
+
+# Fixes locale-related issues: https://gitlab.haskell.org/ghc/ghc/-/issues/8118
+RUN locale-gen en_US.UTF-8
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 ENV USER=root
 COPY install-dapptools.sh /tmp/install-dapptools.sh


### PR DESCRIPTION
The non-explcit setup of LANG env variable caused the bug:
https://gitlab.haskell.org/ghc/ghc/-/issues/8118 at random intervals.

This commits installes the locale package and sets the appropriate env
variabvles.